### PR TITLE
Re-enable Travis container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: clojure
 
-sudo: required
-dist: trusty
+sudo: false
 
 cache:
   directories:


### PR DESCRIPTION
This should make our builds faster. It was previously disabled because we were getting disk space errors, which are probably a noisy neighbor problem.