### PR TITLE
Syslog supports JSON.

### DIFF
--- a/script/syslog-ng/syslog-ng.conf
+++ b/script/syslog-ng/syslog-ng.conf
@@ -3,16 +3,37 @@
 @include "scl.conf"
 
 source s_tcp {
-    network(port(601));
+    syslog(transport("tcp") port(601));
+};
+
+parser p_mixed {
+  channel {
+    junction {
+      channel {
+        parser { json-parser(prefix(".parsed.")); };
+        flags(final);
+      };
+      channel {
+        flags(final);
+      };
+    };
+  };
 };
 
 destination d_file {
     file("/var/log/testlogs");
 };
 
+destination d_jsonfile {
+    file("/var/log/jsonfile.json"
+      template("$(format-json --scope selected_macros --scope dot_nv_pairs)\n")
+    );
+};
+
 destination d_kafka {
     kafka(
         client_lib_dir("/opt/kafka/libs/*.jar:/usr/share/kafka/lib/*.jar")
+        template("$(format-json --scope selected_macros --scope dot_nv_pairs)\n")
         kafka_bootstrap_servers("kafka:9092")
         topic("test1")
     );
@@ -26,5 +47,12 @@ log {
 
 log {
     source(s_tcp);
+    parser(p_mixed);
+    destination(d_jsonfile);
+};
+
+log {
+    source(s_tcp);
+    parser(p_mixed);
     destination(d_kafka);
 };


### PR DESCRIPTION
syslog-ng now can receive messages either with or without JSON. It
always sends JSON out to Kafka. If the original message was JSON, it
will be parsed and included in the "_parsed" field of the resulting JSON
output.

For now this is still just stored raw in the MySQL database, since it's
not worth putting in extra effort into that DB at this point.