### PR TITLE
Can successfully docker build now, with npm installed in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN mkdir /etc/service/aeron
 
 RUN apt-get install -y oracle-java8-installer
 
+RUN apt-get install -y npm
+
 # Install lein -- https://github.com/Quantisan/docker-clojure/blob/master/Dockerfile
 ENV LEIN_VERSION=2.5.3
 ENV LEIN_INSTALL=/usr/local/bin/


### PR DESCRIPTION
Resolves: https://github.com/RackSec/desdemona/issues/76

This is solved the dumb way, just by installing npm. I couldn't figure out how to configure project.clj such that npm isn't required to build the jar.