### PR TITLE
Improved frontend setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ function, giving it an Onyx ID and ZooKeeper address.
 
 ### Run the front-end for development
 
-First, make sure you have [Leiningen](http://leiningen.org/) installed. Run `lein sass watch & lein fighweel`. This will start a Leiningen server at `http://localhost:3449/` as well as automatically watch, compile and inject the project source files for you.
+First, make sure you have [Leiningen](http://leiningen.org/) installed and then run `lein figsass` from the project directory. This will start a Leiningen server at `http://localhost:3449/` as well as automatically watch, compile and inject the project source files for you.
+
+`lein figsass` is just an alias running two tasks in parallel: `scss :dev auto` and `figwheel`. For Sass compilation, project assumes you have [sassc](https://github.com/sass/sassc) binary installed. You can use different binary by changing the `:executable` under `:scss` inside `project.clj`.
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
             [lein-figwheel "0.5.0-1"]
             [lein-npm "0.6.2"]
             [lein-doo "0.1.6"]
-            [lein-sassy "1.0.7"]]
+            [lein-scss "0.2.3"]]
   :npm {:dependencies [[karma ""]
                        [karma-cljs-test ""]
                        [karma-firefox-launcher ""]]}
@@ -56,8 +56,11 @@
                         :compiler {:main "desdemona.ui.runner"
                                    :output-to "target/cljs-tests/test.js"
                                    :optimizations :none}}]}
-  :sass {:src "resources/ui/sass"
-        :dst "resources/ui/css"}
+  :scss {:builds
+         {:dev {:source-dir "resources/ui/sass/"
+                :dest-dir "resources/ui/css/"
+                :executable "sassc"
+                :args ["-m" "-I" "resources/ui/sass/" "-t" "nested"]}}}
   :doo {:paths {:karma "node_modules/karma/bin/karma"}}
   :figwheel {:http-server-root "ui"
              :css-dirs ["resources/ui/css"]

--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,9 @@
             [lein-figwheel "0.5.0-1"]
             [lein-npm "0.6.2"]
             [lein-doo "0.1.6"]
-            [lein-scss "0.2.3"]]
+            [lein-scss "0.2.3"]
+            [lein-pdo "0.1.1"]]
+  :aliases {"figsass" ["pdo" ["scss" ":dev" "auto"] ["figwheel"]]}
   :npm {:dependencies [[karma ""]
                        [karma-cljs-test ""]
                        [karma-firefox-launcher ""]]}

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
 
                  [org.clojure/clojurescript "1.7.228"]
 
-                 [reagent "0.5.1"]
+                 [reagent "0.6.0-alpha"]
                  [reagent-forms "0.5.21"]
                  [reagent-utils "0.1.7"]
                  [hiccup "1.0.5"]
@@ -28,7 +28,7 @@
                  [venantius/accountant "0.1.7"]
                  [com.cemerick/piggieback "0.2.2-SNAPSHOT"]
                  [org.clojure/tools.nrepl "0.2.12"]
-                 [cljsjs/react-bootstrap "0.25.1-0"]
+                 [cljsjs/react-bootstrap "0.28.1-1"]
 
                  [org.clojure/core.logic "0.8.10"]
                  [org.clojure/core.match "0.3.0-alpha4"]]

--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [venantius/accountant "0.1.7"]
                  [com.cemerick/piggieback "0.2.2-SNAPSHOT"]
                  [org.clojure/tools.nrepl "0.2.12"]
-                 [cljsjs/react-bootstrap "0.28.1-1"]
+                 [cljsjs/react-bootstrap "0.28.1-1" :exclusions [org.webjars.bower/jquery]]
 
                  [org.clojure/core.logic "0.8.10"]
                  [org.clojure/core.match "0.3.0-alpha4"]]


### PR DESCRIPTION
- react-bootstrap no longer loads a bunch of jquery versions
- new task `lein figsass` runs frontend while depending on users local binaries for Sass compilation (sassc by default) (fixes #83)